### PR TITLE
Register the tracer to different Prometheus register

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -11,9 +11,6 @@ var _ prometheus.Collector = (*PoolStatsCollector)(nil)
 
 // PoolStatsCollector is a Prometheus pool collector for pgx metrics.
 type PoolStatsCollector struct {
-	// internal pool
-	pools []*pgxpool.Pool
-	// metrics
 	acquireConns            *prometheus.Desc
 	canceledAcquireCount    *prometheus.Desc
 	constructingConns       *prometheus.Desc
@@ -24,6 +21,7 @@ type PoolStatsCollector struct {
 	newConnsCount           *prometheus.Desc
 	maxLifetimeDestroyCount *prometheus.Desc
 	maxIdleDestroyCount     *prometheus.Desc
+	pools                   []*pgxpool.Pool
 }
 
 // NewPoolStatsCollector returns a new collector.

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgx-contrib/pgxprom"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var count int
@@ -16,7 +17,11 @@ func ExampleTracer() {
 		panic(err)
 	}
 
-	config.ConnConfig.Tracer = &pgxprom.Tracer{}
+	tracer := pgxprom.NewTracer()
+	// Register the tracer with the default prometheus registerer
+	tracer.Register(prometheus.DefaultRegisterer)
+	// set the tracer on the config
+	config.ConnConfig.Tracer = tracer
 
 	conn, err := pgxpool.NewWithConfig(context.TODO(), config)
 	if err != nil {


### PR DESCRIPTION
In order to unify the API and support different Prometheus register, you
will need to use the tracer constructor and register function.

Signed-off-by: Svetlin Ralchev <iamralch@users.noreply.github.com>
